### PR TITLE
fix: prevent download on say button

### DIFF
--- a/src/blocks/MainUI.vue
+++ b/src/blocks/MainUI.vue
@@ -33,7 +33,7 @@
         <v-layout>
           <v-row>
             <v-col :sm="isYandex?11:12">
-              <v-btn block @click="say">
+              <v-btn block @click="say()">
                 {{ playing ? 'Остановить' : 'Сказать' }}
               </v-btn>
             </v-col>


### PR DESCRIPTION
## Summary
- ensure click handler for say button invokes function without default event parameter, preventing unintended download

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68aba1d730b883309f5b93cee9c0c657