### PR TITLE
feat: add Vuetify dark theme toggle

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app id="app" light>
+  <v-app id="app">
     <v-overlay :value="loading">
       <v-progress-circular indeterminate size="64"></v-progress-circular>
     </v-overlay>
@@ -19,6 +19,7 @@ import MainUI from "./blocks/MainUI.vue";
 import Setup from "./blocks/Setup.vue";
 import Store from "./lib/Store";
 import ee from "./registerServiceWorker";
+import LocalMemory from "./lib/LocalMemory";
 
 @Component({
   components: {
@@ -35,8 +36,9 @@ export default class App extends Vue {
     this.auth = true;
   }
   async mounted() {
+    this.$vuetify.theme.dark = !!LocalMemory.instance.getBoolean("darkTheme", false);
     console.log('created');
-    
+
     await fireapp.auth().setPersistence(fireapp.auth.Auth.Persistence.LOCAL);
     fireapp.auth().onAuthStateChanged(state => {
       this.auth = !!state;

--- a/src/blocks/Settings.vue
+++ b/src/blocks/Settings.vue
@@ -1,5 +1,6 @@
 <template>
   <v-container>
+    <v-switch class="ma-2" v-model="darkTheme" label="Темная тема"></v-switch>
     <v-tabs v-model="tab" background-color="accent-4" center-active dark centered>
       <v-tab>Выбор голоса</v-tab>
       <v-tab>Адаптация интерфейса</v-tab>
@@ -21,11 +22,25 @@ import Component from "vue-class-component";
 import VoiceSettings from "./components/VoiceSettings.vue";
 import AdaptiveSettings from "./components/AdaptiveSettings.vue";
 import ImportGlobal from "./components/ImportGlobal.vue";
+import LocalMemory from "../lib/LocalMemory";
+import { Watch } from "vue-property-decorator";
 
 @Component({
   components: { VoiceSettings, AdaptiveSettings, ImportGlobal }
 })
 export default class Settings extends Vue {
   tab = 0;
+  lc = LocalMemory.instance;
+  darkTheme: boolean = !!this.lc.getBoolean("darkTheme", false);
+
+  @Watch("darkTheme")
+  onDarkTheme(value: boolean) {
+    this.$vuetify.theme.dark = value;
+    this.lc.setBoolean("darkTheme", value);
+  }
+
+  mounted() {
+    this.$vuetify.theme.dark = this.darkTheme;
+  }
 }
 </script>

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -6,6 +6,7 @@ Vue.use(Vuetify);
 
 export default new Vuetify({
   theme: {
+    dark: false,
     themes: {
       light: {
         primary: colors.red.accent1, // #E53935


### PR DESCRIPTION
## Summary
- initialize Vuetify with dark theme support
- add theme switch in Settings saving choice in LocalMemory
- load saved theme preference on startup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68acbc8e49888330a35212acf7cbf50a