### PR TITLE
feat: add shortcut help dialog and contextual hints

### DIFF
--- a/src/blocks/Bank.vue
+++ b/src/blocks/Bank.vue
@@ -8,6 +8,14 @@
     @keydown.86.self="isPaste = !isPaste"
   >
     <v-layout>
+      <v-flex xs12 class="text-right">
+        <v-tooltip bottom>
+          <template v-slot:activator="{ on, attrs }">
+            <v-icon small color="primary" v-bind="attrs" v-on="on">mdi-help-circle</v-icon>
+          </template>
+          <span>Выбирайте элементы с помощью клавиатуры</span>
+        </v-tooltip>
+      </v-flex>
       <v-flex xs12 v-if="cid === null">
         <l-list
           @select="cselect"

--- a/src/blocks/LHeader.vue
+++ b/src/blocks/LHeader.vue
@@ -20,12 +20,9 @@
         >
           <v-icon>mdi-brain</v-icon>
         </v-btn>
-        <v-btn
-          @click="$emit('shortcut')"
-          icon
-          title="Справка по сочитаниям клавиш"
-        >
-          <v-icon>mdi-apple-keyboard-command</v-icon>
+        <v-btn text @click="shortcutDialog = true" title="Справка по сочетаниям клавиш">
+          <v-icon left>mdi-apple-keyboard-command</v-icon>
+          Горячие клавиши
         </v-btn>
 
         <v-btn
@@ -39,7 +36,7 @@
           <v-icon>mdi-eye</v-icon>
         </v-btn>
         <v-btn @click="saveOnSayClick()" icon title="Стенограмма">
-          <v-icon>{{!saveOnSay?'mdi-pencil':'mdi-pencil-box'}}</v-icon>  
+          <v-icon>{{!saveOnSay?'mdi-pencil':'mdi-pencil-box'}}</v-icon>
         </v-btn>
       </v-toolbar-items>
       <v-toolbar-items>
@@ -48,6 +45,7 @@
         </v-btn>
       </v-toolbar-items>
     </v-toolbar>
+    <shortcut-list v-model="shortcutDialog" />
   </header>
 </template>
 
@@ -56,12 +54,16 @@ import LocalMemory from "@/lib/LocalMemory";
 import Vue from "vue";
 import Component from "vue-class-component";
 import { Prop } from "vue-property-decorator";
+import ShortcutList from "./ShortcutList.vue";
 
-@Component
+@Component({
+  components: { ShortcutList }
+})
 export default class LHeader extends Vue {
   @Prop() settingsMode: boolean | undefined;
   @Prop({ default: 0 }) chat: number | undefined;
   saveOnSay = false;
+  shortcutDialog = false;
   mounted() {
     this.saveOnSay = !!LocalMemory.instance.getBoolean("saveOnSay", false);
   }

--- a/src/blocks/MainUI.vue
+++ b/src/blocks/MainUI.vue
@@ -2,7 +2,6 @@
   <div fill-height  >
     <l-header
       @show="showMode = true"
-      @shortcut="shortcutMode = true"
       @settings="settingsMode = !settingsMode"
       :settingsMode="settingsMode"
       :chat="chat"
@@ -17,7 +16,6 @@
         lc.setBoolean('tutorial', false)
       "
     />
-    <shortcut-list v-if="shortcutMode" @close="shortcutMode = false" />
     <settings v-if="settingsMode" />
     <brain v-else-if="brainMode"
     @quit="(text)=>{textForSpeak[chat]=text; brainMode = false}" />
@@ -69,7 +67,6 @@ import Quickes from './Quickes.vue'
 import Settings from './Settings.vue'
 import MainInput from './components/MainInput.vue'
 import Brain from './components/Brain.vue'
-import ShortcutList from './ShortcutList.vue'
 import LocalMemory from '../lib/LocalMemory'
 import { Watch } from 'vue-property-decorator'
 import { analytics } from 'firebase'
@@ -82,7 +79,6 @@ import { analytics } from 'firebase'
     Quickes,
     Settings,
     Tutorial,
-    ShortcutList,
     Brain
   },
 })
@@ -91,7 +87,6 @@ export default class MainUI extends Vue {
   textForSpeak: string[] = ['', '', '']
   showMode: boolean = false
   settingsMode = false
-  shortcutMode = false
   brainMode = false
   isQuickes = true
   isBank = true

--- a/src/blocks/Quickes.vue
+++ b/src/blocks/Quickes.vue
@@ -1,5 +1,13 @@
 <template>
   <div width="100%" tabindex="0" class="quickes group" @keydown="keydown">
+    <div class="text-right mb-1">
+      <v-tooltip bottom>
+        <template v-slot:activator="{ on, attrs }">
+          <v-icon small color="primary" v-bind="attrs" v-on="on">mdi-help-circle</v-icon>
+        </template>
+        <span>Нажмите 1-6 для выбора фразы</span>
+      </v-tooltip>
+    </div>
     <button-row :items="phrases" :focus="false" @buttonclick="say" />
   </div>
 </template>

--- a/src/blocks/ShortcutList.vue
+++ b/src/blocks/ShortcutList.vue
@@ -1,113 +1,58 @@
 <template>
-  <v-overlay>
-    
-    <v-simple-table>
-        <thead>
-          <tr>
-            <th class="text-left">Сочетание</th>
-            <th class="text-left">Блок</th>
-            <th class="text-left">Функция</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="(item, i) of shortcuts" :key="i">
-            <td>
-              <span v-if="item.mod">ctrl+</span>
-              {{ item.key }}
-            </td>
-            <td>{{ item.block }}</td>
-            <td>{{ item.func }}</td>
-          </tr>
-        </tbody>
-    </v-simple-table>
-
-    <v-btn fab  right small color="primary" @click="$emit('close')">
-      <v-icon dark>mdi-close</v-icon>
-    </v-btn>
-  </v-overlay>
+  <v-dialog v-model="value" max-width="600">
+    <v-card>
+      <v-card-title class="headline">Горячие клавиши</v-card-title>
+      <v-card-text>
+        <v-simple-table>
+          <thead>
+            <tr>
+              <th class="text-left">Сочетание</th>
+              <th class="text-left">Описание</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(item, i) in shortcuts" :key="i">
+              <td>{{ item.key }}</td>
+              <td>{{ item.desc }}</td>
+            </tr>
+          </tbody>
+        </v-simple-table>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn text @click="$emit('input', false)">Закрыть</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
 </template>
 
 <script lang="ts">
 import Vue from "vue";
 import Component from "vue-class-component";
+import { Prop } from "vue-property-decorator";
 
 @Component
-export default class ShortcutLixt extends Vue {
-  shortcuts: Shortcut[] = [
-    {
-      key: "i",
-      mod: false,
-      func: "Сфокусироваться на поле ввода",
-      block: "Везде"
-    },
-    {
-      key: "1...5",
-      mod: true,
-      func: "Выбрать подсказку из предикатора",
-      block: "Поле ввода"
-    },
-    {
-      key: "Backspace",
-      mod: true,
-      func: "Очистить поле ввода",
-      block: "Поле ввода"
-    },
-    {
-      key: "↑",
-      mod: true,
-      func: "Переключиться на предыдущий чат",
-      block: "Поле ввода"
-    },
-    {
-      key: "↓",
-      mod: true,
-      func: "Переключиться на следующий чат",
-      block: "Поле ввода"
-    },
-    {
-      key: "0",
-      mod: true,
-      func: "Сфокусироваться на быстрых фразах",
-      block: "Везде"
-    },
-    {
-      key: "1...6",
-      mod: false,
-      func: "Выбрать быструю фразу",
-      block: "Быстрые фразы"
-    },
-    {
-      key: "Ж",
-      mod: true,
-      func: "Сфокусироваться на банке фраз",
-      block: "Везде"
-    },
+export default class ShortcutList extends Vue {
+  @Prop({ default: false }) value!: boolean;
 
-    {
-      key: "1...9",
-      mod: false,
-      func: "Выбрать категорию/фразу",
-      block: "Банк фраз"
-    },
-    {
-      key: "V",
-      mod: false,
-      func: "Включить режим вставки",
-      block: "Банк фраз"
-    },
-    {
-      key: "R",
-      mod: false,
-      func: "Выбрать случайную фразу",
-      block: "Банк фраз"
-    }
+  shortcuts: Shortcut[] = [
+    { key: "Ctrl + I", desc: "Сфокусироваться на поле ввода" },
+    { key: "Ctrl + 1...5", desc: "Выбрать подсказку из предикатора" },
+    { key: "Ctrl + Backspace", desc: "Очистить поле ввода" },
+    { key: "Ctrl + ↑", desc: "Переключиться на предыдущий чат" },
+    { key: "Ctrl + ↓", desc: "Переключиться на следующий чат" },
+    { key: "Ctrl + 0", desc: "Сфокусироваться на быстрых фразах" },
+    { key: "1...6", desc: "Выбрать быструю фразу" },
+    { key: "Ctrl + Ж", desc: "Сфокусироваться на банке фраз" },
+    { key: "1...9", desc: "Выбрать категорию/фразу в банке" },
+    { key: "V", desc: "Включить режим вставки" },
+    { key: "R", desc: "Выбрать случайную фразу" }
   ];
 }
 
 interface Shortcut {
   key: string;
-  mod: boolean;
-  block: "Везде" | "Поле ввода" | "Быстрые фразы" | "Банк фраз";
-  func: string;
+  desc: string;
 }
 </script>
+


### PR DESCRIPTION
## Summary
- add "Горячие клавиши" button to header with dialog listing shortcuts
- list keyboard shortcut combinations with localized descriptions
- show contextual help icons in Bank and Quickes components

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68acbc90151083309627fe0dc18cf403