### PR TITLE
feat: improve overlay accessibility

### DIFF
--- a/src/blocks/components/Overlay.vue
+++ b/src/blocks/components/Overlay.vue
@@ -1,6 +1,6 @@
 <template>
-  <div :class="{overlay:active}" @click="click">
-    <div class="content">
+  <div :class="{overlay:active}" @click="click" @keydown="onKeydown" ref="overlay" tabindex="-1">
+    <div class="content" ref="content">
       <slot></slot>
     </div>
   </div>
@@ -9,6 +9,7 @@
 <script lang="ts">
 import Vue from "vue";
 import Component from "vue-class-component";
+import { Watch } from "vue-property-decorator";
 
 @Component({
   name: "Overlay",
@@ -24,6 +25,70 @@ import Component from "vue-class-component";
   }
 })
 export default class Overlay extends Vue {
+  private previouslyFocused: HTMLElement | null = null;
+
+  mounted() {
+    if (this.active) {
+      this.activate();
+    }
+  }
+
+  @Watch("active")
+  onActiveChange(val: boolean) {
+    if (val) this.activate();
+    else this.deactivate();
+  }
+
+  activate() {
+    this.previouslyFocused = document.activeElement as HTMLElement;
+    this.$nextTick(() => {
+      const content = this.$refs.content as HTMLElement | undefined;
+      const focusable = content?.querySelector<HTMLElement>(this.focusableSelector);
+      if (focusable) focusable.focus();
+      else (this.$refs.overlay as HTMLElement)?.focus();
+    });
+  }
+
+  deactivate() {
+    this.previouslyFocused?.focus();
+    this.previouslyFocused = null;
+  }
+
+  get focusableSelector() {
+    return 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex]:not([tabindex="-1"]), [contenteditable]';
+  }
+
+  onKeydown(e: KeyboardEvent) {
+    if (!this.active) return;
+    if (e.key === "Escape" || e.key === "Esc") {
+      e.preventDefault();
+      this.$emit("quit");
+      return;
+    }
+    if (e.key === "Tab") {
+      const content = this.$refs.content as HTMLElement | undefined;
+      const focusable = content?.querySelectorAll<HTMLElement>(this.focusableSelector);
+      const first = focusable ? focusable[0] : null;
+      const last = focusable ? focusable[focusable.length - 1] : null;
+      if (!first || !last) {
+        e.preventDefault();
+        (this.$refs.overlay as HTMLElement)?.focus();
+        return;
+      }
+      if (e.shiftKey) {
+        if (document.activeElement === first || document.activeElement === this.$refs.overlay) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last || document.activeElement === this.$refs.overlay) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+  }
+
   click(e: PointerEvent) {
     if (!e.target) return;
     if ((<Element>e.target).classList.contains("overlay")) {


### PR DESCRIPTION
## Summary
- add ESC key and focus trapping to overlay component
- return focus to triggering element when overlay closes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Build failed with errors)*

------
https://chatgpt.com/codex/tasks/task_b_68acbc9729fc833095239351e09c645a